### PR TITLE
Fix the issue when run MTP  with model list

### DIFF
--- a/ModelCoverageTest.py
+++ b/ModelCoverageTest.py
@@ -8,7 +8,6 @@ from vllm import LLM, SamplingParams
 
 
 def setup_logging():
-    """配置日志记录"""
     current_date = datetime.now().strftime('%Y%m%d')
     log_file = f"mct-{current_date}.log"
     logging.basicConfig(
@@ -23,13 +22,12 @@ class InferenceEngine:
         self.model_cache_dir = os.path.expanduser("~/.cache/huggingface/hub/")
 
     def infer_with_model(self, model_id, gpus):
-        """使用指定模型和GPU数量进行推理"""
         try:
             if not isinstance(gpus, int) or gpus <= 0:
                 logging.error(f"<vLLM-CMT> Provided GPU count is invalid for model {model_id}: {gpus}")
                 return "FAILED"
 
-            tp = gpus  # Use the GPU count directly as tensor_parallel_size
+            tp = gpus
             logging.info(f"<vLLM-CMT> Inference Model {model_id}, TP {tp}")
             llm = LLM(
                 model=model_id,
@@ -55,7 +53,6 @@ class InferenceEngine:
             return "FAILED"
 
     def delete_model_cache(self):
-        """删除模型缓存目录"""
         try:
             if os.path.exists(self.model_cache_dir):
                 shutil.rmtree(self.model_cache_dir)
@@ -67,7 +64,6 @@ class InferenceEngine:
 
 
 def load_csv_file(csv_file):
-    """加载CSV文件并验证其格式"""
     if not os.path.isfile(csv_file):
         logging.error(f"<vLLM-CMT> Provided CSV file does not exist: {csv_file}")
         raise FileNotFoundError(f"CSV file does not exist: {csv_file}")
@@ -80,7 +76,6 @@ def load_csv_file(csv_file):
 
 
 def save_results_to_csv(df, csv_file):
-    """将结果保存到CSV文件"""
     base_name, ext = os.path.splitext(csv_file)
     output_csv_file = f"{base_name}_results{ext}"
     df.to_csv(output_csv_file, index=False)
@@ -88,31 +83,24 @@ def save_results_to_csv(df, csv_file):
 
 
 def main():
-    """主程序逻辑"""
     setup_logging()
     parser = ArgumentParser(description="Run inference on models specified in a CSV file.")
     parser.add_argument("--csv", type=str, required=True, help="Path to the input CSV file")
     args = parser.parse_args()
 
     try:
-        # 加载CSV文件
         df = load_csv_file(args.csv)
-
-        # 初始化推理引擎
         engine = InferenceEngine()
 
-        # 遍历CSV文件中的每一行并执行推理
         for index, row in df.iterrows():
             model_id = row['model_id']
-            gpus = int(row['gpus'])  # 解析GPU数量
+            gpus = int(row['gpus'])
             status = engine.infer_with_model(model_id, gpus)
             logging.info(f"<vLLM-CMT> Model {model_id} inference status: {status}")
 
-            # 更新结果并保存到CSV文件
             df.loc[index, 'status'] = status
             save_results_to_csv(df, args.csv)
 
-            # 删除模型缓存
             engine.delete_model_cache()
 
     except Exception as e:

--- a/ModelCoverageTest.py
+++ b/ModelCoverageTest.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 from datetime import datetime
-import torch
 import logging
 from argparse import ArgumentParser
 import pandas as pd
@@ -43,16 +42,16 @@ class InferenceEngine:
             logging.error(f"<vLLM-CMT> Error during inference for model {model_id}: {e}")
             return "FAILED"
 
-def delete_model_cache():
-    try:
-        cache_dir = os.path.expanduser("~/.cache/huggingface/hub/")
-        if os.path.exists(cache_dir):
-            shutil.rmtree(cache_dir)
-            logging.info(f"<vLLM-CMT> Model cache directory deleted: {cache_dir}")
-        else:
-            logging.warning(f"<vLLM-CMT> Model cache directory does not exist: {cache_dir}")
-    except Exception as e:
-        logging.error(f"<vLLM-CMT> Error occurred while deleting model cache: {e}")
+    def delete_model_cache(self):
+        try:
+            cache_dir = os.path.expanduser("~/.cache/huggingface/hub/")
+            if os.path.exists(cache_dir):
+                shutil.rmtree(cache_dir)
+                logging.info(f"<vLLM-CMT> Model cache directory deleted: {cache_dir}")
+            else:
+                logging.warning(f"<vLLM-CMT> Model cache directory does not exist: {cache_dir}")
+        except Exception as e:
+            logging.error(f"<vLLM-CMT> Error occurred while deleting model cache: {e}")
 
 def main():
     parser = ArgumentParser(description="Run inference on models specified in a CSV file.")
@@ -86,7 +85,7 @@ def main():
             df.to_csv(output_csv_file, index=False)
             logging.info(f"<vLLM-CMT> Intermediate results saved to: {output_csv_file}")
             
-            delete_model_cache()
+            engine.delete_model_cache()
         
     except Exception as e:
         logging.error(f"<vLLM-CMT> Error occurred while processing CSV file or models: {e}")

--- a/ModelCoverageTest.py
+++ b/ModelCoverageTest.py
@@ -6,28 +6,40 @@ from argparse import ArgumentParser
 import pandas as pd
 from vllm import LLM, SamplingParams
 
-current_date = datetime.now().strftime('%Y%m%d')
-log_file = f"mct-{current_date}.log"
-logging.basicConfig(filename=log_file, level=logging.DEBUG, 
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+
+def setup_logging():
+    """配置日志记录"""
+    current_date = datetime.now().strftime('%Y%m%d')
+    log_file = f"mct-{current_date}.log"
+    logging.basicConfig(
+        filename=log_file,
+        level=logging.DEBUG,
+        format='%(asctime)s - %(levelname)s - %(message)s'
+    )
+
 
 class InferenceEngine:
+    def __init__(self):
+        self.model_cache_dir = os.path.expanduser("~/.cache/huggingface/hub/")
+
     def infer_with_model(self, model_id, gpus):
+        """使用指定模型和GPU数量进行推理"""
         try:
             if not isinstance(gpus, int) or gpus <= 0:
                 logging.error(f"<vLLM-CMT> Provided GPU count is invalid for model {model_id}: {gpus}")
                 return "FAILED"
-              
+
             tp = gpus  # Use the GPU count directly as tensor_parallel_size
             logging.info(f"<vLLM-CMT> Inference Model {model_id}, TP {tp}")
-            llm = LLM(model=model_id,
-                      tensor_parallel_size=tp,
-                      trust_remote_code=True,
-                      gpu_memory_utilization=0.95,
-                      max_model_len=1024,
-                      enforce_eager=True,
-                      load_format="dummy"
-                     )
+            llm = LLM(
+                model=model_id,
+                tensor_parallel_size=tp,
+                trust_remote_code=True,
+                gpu_memory_utilization=0.95,
+                max_model_len=1024,
+                enforce_eager=True,
+                load_format="dummy"
+            )
             prompts = ["The capital of France is"]
             outputs = llm.generate(prompts, SamplingParams(temperature=0.8, top_p=0.9))
             if not outputs or len(outputs) == 0:
@@ -43,52 +55,69 @@ class InferenceEngine:
             return "FAILED"
 
     def delete_model_cache(self):
+        """删除模型缓存目录"""
         try:
-            cache_dir = os.path.expanduser("~/.cache/huggingface/hub/")
-            if os.path.exists(cache_dir):
-                shutil.rmtree(cache_dir)
-                logging.info(f"<vLLM-CMT> Model cache directory deleted: {cache_dir}")
+            if os.path.exists(self.model_cache_dir):
+                shutil.rmtree(self.model_cache_dir)
+                logging.info(f"<vLLM-CMT> Model cache directory deleted: {self.model_cache_dir}")
             else:
-                logging.warning(f"<vLLM-CMT> Model cache directory does not exist: {cache_dir}")
+                logging.warning(f"<vLLM-CMT> Model cache directory does not exist: {self.model_cache_dir}")
         except Exception as e:
             logging.error(f"<vLLM-CMT> Error occurred while deleting model cache: {e}")
 
+
+def load_csv_file(csv_file):
+    """加载CSV文件并验证其格式"""
+    if not os.path.isfile(csv_file):
+        logging.error(f"<vLLM-CMT> Provided CSV file does not exist: {csv_file}")
+        raise FileNotFoundError(f"CSV file does not exist: {csv_file}")
+
+    df = pd.read_csv(csv_file)
+    if 'model_id' not in df.columns or 'gpus' not in df.columns:
+        logging.error("<vLLM-CMT> CSV file must contain 'model_id' and 'gpus' columns.")
+        raise ValueError("CSV file must contain 'model_id' and 'gpus' columns.")
+    return df
+
+
+def save_results_to_csv(df, csv_file):
+    """将结果保存到CSV文件"""
+    base_name, ext = os.path.splitext(csv_file)
+    output_csv_file = f"{base_name}_results{ext}"
+    df.to_csv(output_csv_file, index=False)
+    logging.info(f"<vLLM-CMT> Results saved to: {output_csv_file}")
+
+
 def main():
+    """主程序逻辑"""
+    setup_logging()
     parser = ArgumentParser(description="Run inference on models specified in a CSV file.")
     parser.add_argument("--csv", type=str, required=True, help="Path to the input CSV file")
     args = parser.parse_args()
-    csv_file = args.csv
-    if not os.path.isfile(csv_file):
-        logging.error(f"<vLLM-CMT> Provided CSV file does not exist: {csv_file}")
-        parser.print_help()
-        return
-    
+
     try:
-        df = pd.read_csv(csv_file)
-        if 'model_id' not in df.columns or 'gpus' not in df.columns:
-            logging.error("<vLLM-CMT> CSV file must contain 'model_id' and 'gpus' columns.")
-            raise ValueError("CSV file must contain 'model_id' and 'gpus' columns.")
-        
+        # 加载CSV文件
+        df = load_csv_file(args.csv)
+
+        # 初始化推理引擎
         engine = InferenceEngine()
-        results = []
+
+        # 遍历CSV文件中的每一行并执行推理
         for index, row in df.iterrows():
             model_id = row['model_id']
-            gpus = int(row['gpus'])  # Parse GPU count directly
+            gpus = int(row['gpus'])  # 解析GPU数量
             status = engine.infer_with_model(model_id, gpus)
             logging.info(f"<vLLM-CMT> Model {model_id} inference status: {status}")
-            results.append(status)
-            
-            # Save intermediate results after each model
+
+            # 更新结果并保存到CSV文件
             df.loc[index, 'status'] = status
-            base_name, ext = os.path.splitext(csv_file)
-            output_csv_file = f"{base_name}_results{ext}"
-            df.to_csv(output_csv_file, index=False)
-            logging.info(f"<vLLM-CMT> Intermediate results saved to: {output_csv_file}")
-            
+            save_results_to_csv(df, args.csv)
+
+            # 删除模型缓存
             engine.delete_model_cache()
-        
+
     except Exception as e:
         logging.error(f"<vLLM-CMT> Error occurred while processing CSV file or models: {e}")
+
 
 if __name__ == "__main__":
     main()

--- a/ModelCoverageTest.py
+++ b/ModelCoverageTest.py
@@ -15,11 +15,11 @@ logging.basicConfig(filename=log_file, level=logging.DEBUG,
 class InferenceEngine:
     def infer_with_model(self, model_id, gpus):
         try:
-            if not isinstance(gpus, list) or len(gpus) == 0:
-                logging.error(f"<vLLM-CMT> Provided GPUs list is invalid for model {model_id}: {gpus}")
+            if not isinstance(gpus, int) or gpus <= 0:
+                logging.error(f"<vLLM-CMT> Provided GPU count is invalid for model {model_id}: {gpus}")
                 return "FAILED"
               
-            tp = len(gpus)
+            tp = gpus  # Use the GPU count directly as tensor_parallel_size
             logging.info(f"<vLLM-CMT> Inference Model {model_id}, TP {tp}")
             llm = LLM(model=model_id,
                       tensor_parallel_size=tp,
@@ -32,7 +32,7 @@ class InferenceEngine:
             prompts = ["The capital of France is"]
             outputs = llm.generate(prompts, SamplingParams(temperature=0.8, top_p=0.9))
             if not outputs or len(outputs) == 0:
-                raise ValueError("<vLLM-CMT >No outtputs received from the model.")
+                raise ValueError("<vLLM-CMT> No outputs received from the model.")
             for output in outputs:
                 prompt = output.prompt
                 generated_text = output.outputs[0].text
@@ -74,7 +74,7 @@ def main():
         results = []
         for index, row in df.iterrows():
             model_id = row['model_id']
-            gpus = [int(gpu) for gpu in str(row['gpus']).split(',')]
+            gpus = int(row['gpus'])  # Parse GPU count directly
             status = engine.infer_with_model(model_id, gpus)
             logging.info(f"<vLLM-CMT> Model {model_id} inference status: {status}")
             results.append(status)

--- a/ModelCoverageTest.py
+++ b/ModelCoverageTest.py
@@ -18,8 +18,7 @@ class InferenceEngine:
             if not isinstance(gpus, list) or len(gpus) == 0:
                 logging.error(f"<vLLM-CMT> Provided GPUs list is invalid for model {model_id}: {gpus}")
                 return "FAILED"
-            
-            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, gpus))
+              
             tp = len(gpus)
             logging.info(f"<vLLM-CMT> Inference Model {model_id}, TP {tp}")
             llm = LLM(model=model_id,


### PR DESCRIPTION
When run MTP with model list. The model after one time run Multiple TP of a model will cause the vLLM pending. I try to do many  things like clean GPU cache, kill vLLM pid but all failed. It should be a bug of vLLM subprocess management issue. So I use subprocess to call vLLM inference one by one with model list to workaround the issue.

Another change is redefine the `gpus` the meaning form the gpu id in list to the number of gpus for tensor_parallel_size of vLLM inference engine.